### PR TITLE
Fixes for issues 1 & 2

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,54 +1,64 @@
 @import "syntax-variables";
 
-.editor {
+atom-text-editor, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 }
 
-.editor .gutter {
+atom-text-editor .gutter,
+:host .gutter {
   background-color: @syntax-gutter-background-color;
   color: @syntax-gutter-text-color;
 }
 
-.editor .gutter .line-number.cursor-line {
+atom-text-editor .gutter .line-number.cursor-line,
+:host .gutter .line-number.cursor-line {
   background-color: @syntax-gutter-background-color-selected;
   color: @syntax-gutter-text-color-selected;
 }
 
-.editor .gutter .line-number.cursor-line-no-selection {
+atom-text-editor .gutter .line-number.cursor-line-no-selection,
+:host .gutter .line-number.cursor-line-no-selection {
   color: @syntax-gutter-text-color-selected;
 }
 
-.editor .wrap-guide {
+atom-text-editor .wrap-guide,
+:host .wrap-guide  {
   color: @syntax-wrap-guide-color;
 }
 
-.editor .indent-guide {
+atom-text-editor .indent-guide,
+:host .indent-guide {
   color: @syntax-indent-guide-color;
 }
 
-.editor .invisible-character {
+atom-text-editor .invisible-character,
+:host .invisible-character {
   color: @syntax-invisible-character-color;
 }
 
-.editor .search-results .marker .region {
+atom-text-editor .search-results .marker .region,
+:host .search-results .marker .region {
   background-color: transparent;
   border: @syntax-result-marker-color;
 }
 
-.editor .search-results .marker.current-result .region {
+atom-text-editor .search-results .marker.current-result .region,
+:host .search-results .marker.current-result .region {
   border: @syntax-result-marker-color-selected;
 }
 
-.editor.is-focused .cursor {
+atom-text-editor.is-focused .cursor,
+:host.is-focused .cursor {
   border-color: @syntax-cursor-color;
 }
 
-.editor.is-focused .selection .region {
+atom-text-editor.is-focused .selection .region,
+:host.is-focused .selection .region {
   background-color: @syntax-selection-color;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, :host.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line, :host.is-focused .line.cursor-line {
   background-color: #E4F6D4;
 }
 


### PR DESCRIPTION
- Use the `atom-text-editor` tag instead of the `editor` class.
- Target the selector `:host, atom-text-editor` instead of `.editor`
  for shadow DOM support.
